### PR TITLE
Add expected fields query parameter

### DIFF
--- a/trunk/public/js/facebook-login.js
+++ b/trunk/public/js/facebook-login.js
@@ -22,7 +22,7 @@
                  * "me" refers to the current FB user, console.log( response )
                  * for a full list.
                  */
-                FB.api('/me', function(response) {
+                FB.api('/me?fields=first_name,last_name,email,link', function(response) {
                     var fb_response = response;
 
                     /**


### PR DESCRIPTION
The Facebook API only returns `id` and `name` from `/{user}` now. To get the fields the plug-in expects for user creation, they have to be explicitly specified
