### PR TITLE
added action fbl/save_access_token to allow access token to be persisted on some way

### DIFF
--- a/trunk/public/class-facebook-login-public.php
+++ b/trunk/public/class-facebook-login-public.php
@@ -213,6 +213,8 @@ class Facebook_Login_Public {
 
 		$access_token = isset( $_POST['fb_response']['authResponse']['accessToken'] ) ? $_POST['fb_response']['authResponse']['accessToken'] : '';
 
+        do_action('fbl/save_access_token', $access_token);
+
 		// Get user from Facebook with given access token
 		$fb_url = add_query_arg(
 			apply_filters( 'fbl/js_auth_data',


### PR DESCRIPTION
Added an action call so that access_token could be saved on COOKIE, for example, to allow other interactions with Facebook API.

I don`t know if it is good but I found an use in some of my projects, so I share it.