### PR TITLE
Fixed reference to the loading.gif asset

### DIFF
--- a/trunk/public/class-facebook-login-public.php
+++ b/trunk/public/class-facebook-login-public.php
@@ -134,7 +134,7 @@ class Facebook_Login_Public {
 
 		$redirect = apply_filters( 'flp/disconnect_redirect_url', ( is_ssl() ? 'https://' : 'http://' ) . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'] );
 
-		echo apply_filters('fbl/disconnect_button', '<a href="?fbl_disconnect&fb_nonce='. wp_create_nonce( 'fbl_disconnect' ) .'&redirect='.urlencode( $redirect ).'" class="css-fbl "><div>'. __('Disconnect Facebook', 'fbl') .'<img data-no-lazy="1" src="'.site_url('/wp-includes/js/mediaelement/loading.gif').'" alt="" style="display:none"/></div></a>');
+		echo apply_filters('fbl/disconnect_button', '<a href="?fbl_disconnect&fb_nonce='. wp_create_nonce( 'fbl_disconnect' ) .'&redirect='.urlencode( $redirect ).'" class="css-fbl "><div>'. __('Disconnect Facebook', 'fbl') .'<img data-no-lazy="1" src="'.admin_url('images/loading.gif').'" alt="" style="display:none"/></div></a>');
 
 	}
 	/**


### PR DESCRIPTION
First contribution here, so not sure how you guys do things....

found that the asset being referenced at ``/wp-includes/js/mediaelement/loading.gif`` doesn't exist, the closest asset i found was ``wp-admin/images/loading.gif``

sidenote, i did notice that you guys have this file ``trunk/public/img/loading.svg``... 